### PR TITLE
Update eslint, rules, and some style stuff.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
     "brace-style": 2,
     "eol-last": 1,
     "no-nested-ternary": 1,
-    "space-after-keywords": [1, "always"],
+    "keyword-spacing": [ 1, {"before": true, "after": true }],
     "space-before-blocks": [1, "always"],
     "semi": 2,
     "comma-dangle": [2, "never"],

--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ function bumpUpVersion(bumpType) {
 
 
 function validateBranch() {
-  var branches = exec(`git branch`).output;
+  var branches = exec('git branch').output;
   var currentBranch = exec('git rev-parse --abbrev-ref HEAD').output.split('\n')[0];
 
   if (program.branch !== currentBranch) {
@@ -321,4 +321,3 @@ function terminateProcess(code) {
     exit(code);
   }
 }
-

--- a/index.js
+++ b/index.js
@@ -258,12 +258,12 @@ function addFilesAndCreateTag(newVersion) {
   terminateProcess(code);
 
   // ###### Commit files #####
-  var code = exec('git commit -m "chore(release): ' + newVersion + '"').code;
+  var code = exec(`git commit -m "chore(release): ${newVersion}"`).code;
   terminateProcess(code);
 
   // ###### TAG NEW VERSION #####
   info(`>> Time to create the Semantic Tag: ${newVersion}`);
-  var code = exec('git tag ' + newVersion).code;
+  var code = exec(`git tag ${newVersion}`).code;
   terminateProcess(code);
 
   // ###### PUSH CHANGES #####
@@ -290,9 +290,9 @@ function bumpUpVersion(bumpType) {
       var newVersion;
       if (isFirstRelease(latestTag)) {
         newVersion = 'v1.0.0';
-        var w = exec('npm version --no-git-tag-version ' + newVersion).output.split('\n')[0];
+        var w = exec(`npm version --no-git-tag-version ${newVersion}`).output.split('\n')[0];
       } else {
-        newVersion = exec('npm version --no-git-tag-version ' + bumpType).output.split('\n')[0];
+        newVersion = exec(`npm version --no-git-tag-version ${bumpType}`).output.split('\n')[0];
       }
 
       return newVersion;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "cz-customizable": "3.1.0",
-    "eslint": "1.9.0",
+    "eslint": "^3.7.1",
     "istanbul": "0.4.2",
     "jasmine-node": "1.14.5"
   },

--- a/spec/e2eSpec.js
+++ b/spec/e2eSpec.js
@@ -51,19 +51,19 @@ describe('corp-semantic-release', function () {
 
   it('should not change anything in dry mode', function () {
     commitFeat();
-    const out = shell.exec(`node ${__dirname}/../index.js -d`).output;
+    const out = shell.exec('node ${__dirname}/../index.js -d').output;
 
     expect(out).to.include('YOU ARE RUNNING IN DRY RUN MODE');
 
     // clean work directory
-    const gitStatus = shell.exec(`git status`).output;
+    const gitStatus = shell.exec('git status').output;
     expect(gitStatus).to.include('nothing to commit, working directory clean');
   });
 
 
   it('should bump minor version, create CHANGELOG.md file and semantic tag correctly', function () {
     commitFeat();
-    shell.exec(`node ${__dirname}/../index.js -v`).output;
+    shell.exec('node ${__dirname}/../index.js -v').output;
     const expectedVersion = '1.0.0';
 
     // check Semantic Tag
@@ -71,7 +71,7 @@ describe('corp-semantic-release', function () {
 
     // Verify CHANGELOG.md
     let changelog = shell.exec('cat CHANGELOG.md').output;
-    expect(changelog).to.include(`# ${expectedVersion} (${today})`);
+    expect(changelog).to.include('# ${expectedVersion} (${today})');
     expect(changelog).to.include('### Features\n\n');
     expect(changelog).to.include('my first feature');
 
@@ -81,9 +81,9 @@ describe('corp-semantic-release', function () {
 
   it('should run pre-commit script if required', function () {
     commitFeat();
-    const out = shell.exec(`node ${__dirname}/../index.js -v --pre-commit set-version`).output;
+    const out = shell.exec('node ${__dirname}/../index.js -v --pre-commit set-version').output;
 
-    expect(out).to.include(`this is my pre-commit script`);
+    expect(out).to.include('this is my pre-commit script');
   });
 
 
@@ -91,18 +91,18 @@ describe('corp-semantic-release', function () {
     // pre-conditions
     shell.cp(__dirname + '/../testData/CHANGELOG.md', tempDir);
     commitFeat();
-    shell.exec(`node ${__dirname}/../index.js -v`).output;
+    shell.exec('node ${__dirname}/../index.js -v').output;
 
     const expectedVersion = '2.0.0';
 
     // actions
     commitFixWithBreakingChange();
-    shell.exec(`node ${__dirname}/../index.js -v`).output;
+    shell.exec('node ${__dirname}/../index.js -v').output;
 
     // verify
     let changelog = shell.exec('cat CHANGELOG.md').output;
     expect(changelog).to.include('### BREAKING CHANGES\n\n* This should bump major');
-    expect(changelog).to.include(`# [2.0.0](//compare/v1.0.0...v${expectedVersion}) (${today})`);
+    expect(changelog).to.include('# [2.0.0](//compare/v1.0.0...v${expectedVersion}) (${today})');
 
     expectedVersionInPackageJson(expectedVersion);
   });
@@ -110,32 +110,32 @@ describe('corp-semantic-release', function () {
 
   it('should detect release is not necessary', function () {
     commitNonReleaseTypes();
-    const out = shell.exec(`node ${__dirname}/../index.js -v`).output;
+    const out = shell.exec('node ${__dirname}/../index.js -v').output;
 
     expect(out).to.include('Release is not necessary at this point');
 
     // clean work directory
-    const gitStatus = shell.exec(`git status`).output;
+    const gitStatus = shell.exec('git status').output;
     expect(gitStatus).to.include('nothing to commit, working directory clean');
   });
 
 
   it('should NOT make any change when we run multiple times and there are no relevant commits', function () {
     commitWithMessage('initial commit');
-    shell.exec(`node ${__dirname}/../index.js -v`).output;
+    shell.exec('node ${__dirname}/../index.js -v').output;
     const expectedVersion = '0.0.1';
 
-    const gitStatus = shell.exec(`git status`).output;
+    const gitStatus = shell.exec('git status').output;
     expect(gitStatus).to.include('nothing to commit, working directory clean');
 
     // no changes expected, no tags expected
-    const gitTag = shell.exec(`git tag | cat`).output;
+    const gitTag = shell.exec('git tag | cat').output;
     expect(gitTag).to.equal('');
     expectedVersionInPackageJson(expectedVersion);
 
 
     // Then when I ran again
-    shell.exec(`node ${__dirname}/../index.js -v`).output;
+    shell.exec('node ${__dirname}/../index.js -v').output;
     expectedVersionInPackageJson(expectedVersion);
     expect(gitTag).to.equal('');
     expectedVersionInPackageJson(expectedVersion);
@@ -146,26 +146,26 @@ describe('corp-semantic-release', function () {
     commitWithMessage('feat(accounts): commit 1');
     commitFixWithMessage('fix(exampleScope): add extra config');
 
-    shell.exec(`node ${__dirname}/../index.js -v`).output;
+    shell.exec('node ${__dirname}/../index.js -v').output;
     const expectedVersion = '1.0.0';
 
     // version 1.1.0 expected
-    var gitTag = shell.exec(`git tag | cat`).output;
-    expect(gitTag).to.equal(`v${expectedVersion}\n`);
+    var gitTag = shell.exec('git tag | cat').output;
+    expect(gitTag).to.equal('v${expectedVersion}\n');
     expectedVersionInPackageJson(expectedVersion);
 
     // then run again. The same version 1.1.0 expected
-    var out = shell.exec(`node ${__dirname}/../index.js -v`).output;
-    var gitTag = shell.exec(`git tag | cat`).output;
-    expect(gitTag).to.equal(`v${expectedVersion}\n`);
+    var out = shell.exec('node ${__dirname}/../index.js -v').output;
+    var gitTag = shell.exec('git tag | cat').output;
+    expect(gitTag).to.equal('v${expectedVersion}\n');
     expectedVersionInPackageJson(expectedVersion);
     expect(out).to.include('Release is not necessary at this point');
 
 
     // run once more. The same version 1.1.0 expected
-    var out = shell.exec(`node ${__dirname}/../index.js -v`).output;
-    var gitTag = shell.exec(`git tag | cat`).output;
-    expect(gitTag).to.equal(`v${expectedVersion}\n`);
+    var out = shell.exec('node ${__dirname}/../index.js -v').output;
+    var gitTag = shell.exec('git tag | cat').output;
+    expect(gitTag).to.equal('v${expectedVersion}\n');
     expectedVersionInPackageJson(expectedVersion);
     expect(out).to.include('Release is not necessary at this point');
 
@@ -173,23 +173,23 @@ describe('corp-semantic-release', function () {
 
   it('should run if branch is master', function () {
     commitWithMessage('feat(accounts): commit 1');
-    shell.exec(`git checkout -b other-branch`);
+    shell.exec('git checkout -b other-branch');
 
-    const out = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
+    const out = shell.exec('node ${__dirname}/../index.js -v -d').output;
 
     expect(out).to.include('You can not release from branch other than master. Use option --branch to specify branch name.');
 
-    shell.exec(`git checkout master`);
-    const outMaster = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
+    shell.exec('git checkout master');
+    const outMaster = shell.exec('node ${__dirname}/../index.js -v -d').output;
     expect(outMaster).to.include('>>> Your release branch is: master');
   });
 
 
   it('should inform user if package.json does not exist', function () {
     commitWithMessage('feat(accounts): commit 1');
-    shell.exec(`rm package.json`);
+    shell.exec('rm package.json');
 
-    const out = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
+    const out = shell.exec('node ${__dirname}/../index.js -v -d').output;
 
     expect(out).to.include('Cant find your package.json');
   });
@@ -197,10 +197,10 @@ describe('corp-semantic-release', function () {
 
   it('should inform user if name is not present in package.json', function () {
     commitWithMessage('feat(accounts): commit 1');
-    shell.exec(`rm package.json`);
+    shell.exec('rm package.json');
     shell.cp(__dirname + '/../testData/package_noname.json', tempDir + '/package.json');
 
-    const out = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
+    const out = shell.exec('node ${__dirname}/../index.js -v -d').output;
 
     expect(out).to.include('Minimum required fields in your package.json are name and version');
   });
@@ -208,7 +208,7 @@ describe('corp-semantic-release', function () {
   // ####### Helpers ######
 
   function getBranchName() {
-    var branch = shell.exec(`git branch`).output;
+    var branch = shell.exec('git branch').output;
     return branch;
   }
 
@@ -230,22 +230,22 @@ describe('corp-semantic-release', function () {
 
   function commitFixWithMessage(msg) {
     writeFileSync('fix.txt', '');
-    commitWithMessageMultiline(`-m "${msg}"`);
+    commitWithMessageMultiline('-m "${msg}"');
   }
 
   function commitFixWithBreakingChange() {
     writeFileSync('fix.txt', '');
-    const msg = `-m "fix: issue in the app" -m "BREAKING CHANGE:" -m "This should bump major"`;
+    const msg = '-m "fix: issue in the app" -m "BREAKING CHANGE:" -m "This should bump major"';
 
     commitWithMessageMultiline(msg);
   }
 
   function commitWithMessage(msg) {
-    shell.exec(`git add --all && git commit -m "${msg}"`);
+    shell.exec('git add --all && git commit -m "${msg}"');
   }
 
   function commitWithMessageMultiline(msg) {
-    shell.exec(`git add --all && git commit ${msg}`);
+    shell.exec('git add --all && git commit ${msg}');
   }
 
   const today = new Date().toISOString().substring(0, 10);
@@ -254,7 +254,7 @@ describe('corp-semantic-release', function () {
   function expectedGitTag(expectedVersion) {
     // check for new commit
     let gitLog = shell.exec('git log | cat').output;
-    expect(gitLog).to.include(`chore(release): ` + `v` + `${expectedVersion}`);
+    expect(gitLog).to.include('chore(release): ' + 'v' + '${expectedVersion}');
 
     let gitTag = shell.exec('git tag | cat').output;
     expect(gitTag).to.include('v' + expectedVersion);

--- a/spec/e2eSpec.js
+++ b/spec/e2eSpec.js
@@ -51,7 +51,7 @@ describe('corp-semantic-release', function () {
 
   it('should not change anything in dry mode', function () {
     commitFeat();
-    const out = shell.exec('node ${__dirname}/../index.js -d').output;
+    const out = shell.exec(`node ${__dirname}/../index.js -d`).output;
 
     expect(out).to.include('YOU ARE RUNNING IN DRY RUN MODE');
 
@@ -63,7 +63,7 @@ describe('corp-semantic-release', function () {
 
   it('should bump minor version, create CHANGELOG.md file and semantic tag correctly', function () {
     commitFeat();
-    shell.exec('node ${__dirname}/../index.js -v').output;
+    shell.exec(`node ${__dirname}/../index.js -v`).output;
     const expectedVersion = '1.0.0';
 
     // check Semantic Tag
@@ -71,7 +71,7 @@ describe('corp-semantic-release', function () {
 
     // Verify CHANGELOG.md
     let changelog = shell.exec('cat CHANGELOG.md').output;
-    expect(changelog).to.include('# ${expectedVersion} (${today})');
+    expect(changelog).to.include(`# ${expectedVersion} (${today})`);
     expect(changelog).to.include('### Features\n\n');
     expect(changelog).to.include('my first feature');
 
@@ -81,7 +81,7 @@ describe('corp-semantic-release', function () {
 
   it('should run pre-commit script if required', function () {
     commitFeat();
-    const out = shell.exec('node ${__dirname}/../index.js -v --pre-commit set-version').output;
+    const out = shell.exec(`node ${__dirname}/../index.js -v --pre-commit set-version`).output;
 
     expect(out).to.include('this is my pre-commit script');
   });
@@ -91,18 +91,18 @@ describe('corp-semantic-release', function () {
     // pre-conditions
     shell.cp(__dirname + '/../testData/CHANGELOG.md', tempDir);
     commitFeat();
-    shell.exec('node ${__dirname}/../index.js -v').output;
+    shell.exec(`node ${__dirname}/../index.js -v`).output;
 
     const expectedVersion = '2.0.0';
 
     // actions
     commitFixWithBreakingChange();
-    shell.exec('node ${__dirname}/../index.js -v').output;
+    shell.exec(`node ${__dirname}/../index.js -v`).output;
 
     // verify
     let changelog = shell.exec('cat CHANGELOG.md').output;
     expect(changelog).to.include('### BREAKING CHANGES\n\n* This should bump major');
-    expect(changelog).to.include('# [2.0.0](//compare/v1.0.0...v${expectedVersion}) (${today})');
+    expect(changelog).to.include(`# [2.0.0](//compare/v1.0.0...v${expectedVersion}) (${today})`);
 
     expectedVersionInPackageJson(expectedVersion);
   });
@@ -110,7 +110,7 @@ describe('corp-semantic-release', function () {
 
   it('should detect release is not necessary', function () {
     commitNonReleaseTypes();
-    const out = shell.exec('node ${__dirname}/../index.js -v').output;
+    const out = shell.exec(`node ${__dirname}/../index.js -v`).output;
 
     expect(out).to.include('Release is not necessary at this point');
 
@@ -122,7 +122,7 @@ describe('corp-semantic-release', function () {
 
   it('should NOT make any change when we run multiple times and there are no relevant commits', function () {
     commitWithMessage('initial commit');
-    shell.exec('node ${__dirname}/../index.js -v').output;
+    shell.exec(`node ${__dirname}/../index.js -v`).output;
     const expectedVersion = '0.0.1';
 
     const gitStatus = shell.exec('git status').output;
@@ -135,7 +135,7 @@ describe('corp-semantic-release', function () {
 
 
     // Then when I ran again
-    shell.exec('node ${__dirname}/../index.js -v').output;
+    shell.exec(`node ${__dirname}/../index.js -v`).output;
     expectedVersionInPackageJson(expectedVersion);
     expect(gitTag).to.equal('');
     expectedVersionInPackageJson(expectedVersion);
@@ -146,26 +146,26 @@ describe('corp-semantic-release', function () {
     commitWithMessage('feat(accounts): commit 1');
     commitFixWithMessage('fix(exampleScope): add extra config');
 
-    shell.exec('node ${__dirname}/../index.js -v').output;
+    shell.exec(`node ${__dirname}/../index.js -v`).output;
     const expectedVersion = '1.0.0';
 
     // version 1.1.0 expected
     var gitTag = shell.exec('git tag | cat').output;
-    expect(gitTag).to.equal('v${expectedVersion}\n');
+    expect(gitTag).to.equal(`v${expectedVersion}\n`);
     expectedVersionInPackageJson(expectedVersion);
 
     // then run again. The same version 1.1.0 expected
-    var out = shell.exec('node ${__dirname}/../index.js -v').output;
+    var out = shell.exec(`node ${__dirname}/../index.js -v`).output;
     var gitTag = shell.exec('git tag | cat').output;
-    expect(gitTag).to.equal('v${expectedVersion}\n');
+    expect(gitTag).to.equal(`v${expectedVersion}\n`);
     expectedVersionInPackageJson(expectedVersion);
     expect(out).to.include('Release is not necessary at this point');
 
 
     // run once more. The same version 1.1.0 expected
-    var out = shell.exec('node ${__dirname}/../index.js -v').output;
+    var out = shell.exec(`node ${__dirname}/../index.js -v`).output;
     var gitTag = shell.exec('git tag | cat').output;
-    expect(gitTag).to.equal('v${expectedVersion}\n');
+    expect(gitTag).to.equal(`v${expectedVersion}\n`);
     expectedVersionInPackageJson(expectedVersion);
     expect(out).to.include('Release is not necessary at this point');
 
@@ -175,12 +175,12 @@ describe('corp-semantic-release', function () {
     commitWithMessage('feat(accounts): commit 1');
     shell.exec('git checkout -b other-branch');
 
-    const out = shell.exec('node ${__dirname}/../index.js -v -d').output;
+    const out = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
 
     expect(out).to.include('You can not release from branch other than master. Use option --branch to specify branch name.');
 
     shell.exec('git checkout master');
-    const outMaster = shell.exec('node ${__dirname}/../index.js -v -d').output;
+    const outMaster = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
     expect(outMaster).to.include('>>> Your release branch is: master');
   });
 
@@ -189,7 +189,7 @@ describe('corp-semantic-release', function () {
     commitWithMessage('feat(accounts): commit 1');
     shell.exec('rm package.json');
 
-    const out = shell.exec('node ${__dirname}/../index.js -v -d').output;
+    const out = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
 
     expect(out).to.include('Cant find your package.json');
   });
@@ -200,7 +200,7 @@ describe('corp-semantic-release', function () {
     shell.exec('rm package.json');
     shell.cp(__dirname + '/../testData/package_noname.json', tempDir + '/package.json');
 
-    const out = shell.exec('node ${__dirname}/../index.js -v -d').output;
+    const out = shell.exec(`node ${__dirname}/../index.js -v -d`).output;
 
     expect(out).to.include('Minimum required fields in your package.json are name and version');
   });
@@ -230,7 +230,7 @@ describe('corp-semantic-release', function () {
 
   function commitFixWithMessage(msg) {
     writeFileSync('fix.txt', '');
-    commitWithMessageMultiline('-m "${msg}"');
+    commitWithMessageMultiline(`-m "${msg}"`);
   }
 
   function commitFixWithBreakingChange() {
@@ -241,11 +241,11 @@ describe('corp-semantic-release', function () {
   }
 
   function commitWithMessage(msg) {
-    shell.exec('git add --all && git commit -m "${msg}"');
+    shell.exec(`git add --all && git commit -m "${msg}"`);
   }
 
   function commitWithMessageMultiline(msg) {
-    shell.exec('git add --all && git commit ${msg}');
+    shell.exec(`git add --all && git commit ${msg}`);
   }
 
   const today = new Date().toISOString().substring(0, 10);
@@ -254,7 +254,7 @@ describe('corp-semantic-release', function () {
   function expectedGitTag(expectedVersion) {
     // check for new commit
     let gitLog = shell.exec('git log | cat').output;
-    expect(gitLog).to.include('chore(release): ' + 'v' + '${expectedVersion}');
+    expect(gitLog).to.include(`chore(release): v${expectedVersion}`);
 
     let gitTag = shell.exec('git tag | cat').output;
     expect(gitTag).to.include('v' + expectedVersion);


### PR DESCRIPTION
Update eslint package, update the 'space-after-keywords' rule to the
new name, and run the lint.

*Sorry about the tons of CI builds from this PR, I made a real mess.*