### PR TITLE
Add validate-commit-msg for non commitizen commits.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,21 @@
     "chai": "3.5.0",
     "cz-customizable": "3.1.0",
     "eslint": "1.9.0",
+    "ghooks": "^1.3.2",
     "istanbul": "0.4.2",
-    "jasmine-node": "1.14.5"
+    "jasmine-node": "1.14.5",
+    "validate-commit-msg": "^2.8.2"
   },
   "config": {
     "commitizen": {
       "path": "node_modules/cz-customizable"
+    },
+    "validate-commit-msg": {
+      "warnOnFail": false,
+      "helpMessage": "This repository uses angular's commit standards. See https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md for more details."
+    },
+    "ghooks": {
+      "commit-msg": "validate-commit-msg"
     }
   },
   "bin": {


### PR DESCRIPTION
adding validate-commit-msg will ensure users follow commit standards
for semantic-release even if the user does not use commitizen.