### PR TITLE
feat(process): when not on master branch, exit with 0 instead of 1

### DIFF
--- a/spec/system.spec.js
+++ b/spec/system.spec.js
@@ -207,16 +207,18 @@ describe('corp-semantic-release', function() {
     expect(out).to.include('Release is not necessary at this point');
   });
 
-  it('should run if branch is master', function() {
+  it('should only run if branch is master', function() {
     commitWithMessage('feat(accounts): commit 1');
     shell.exec('git checkout -b other-branch');
 
-    const out = semanticRelease(`-v -d`);
+    const out = semanticRelease(`-v -d --post-success "echo foo"`);
 
+    expect(out).not.to.include('Skipping post-success command');
     expect(out).to.include('You can only release from the master branch. Use option --branch to specify branch name.');
 
     shell.exec('git checkout master');
-    const outMaster = semanticRelease(`-v -d`);
+    const outMaster = semanticRelease(`-v -d --post-success "echo foo"`);
+    expect(outMaster).to.include('Skipping post-success command');
     expect(outMaster).to.include('>>> Your release branch is: master');
   });
 

--- a/spec/validateBranch.spec.js
+++ b/spec/validateBranch.spec.js
@@ -9,7 +9,7 @@ describe('validateBranch', () => {
 
   afterEach(() => revert());    // revert the mocking of anything
 
-  it('should show a message if the current branch is not the release branch and exit', () => {
+  it('should show a message if the current branch is not the release branch and exit with 0', () => {
     let exitCode;
     revert = validateBranch.__set__({
       shell: {
@@ -26,7 +26,7 @@ describe('validateBranch', () => {
     });
 
     expect(output[0]).to.include(`You can only release from the bar branch. Use option --branch to specify branch name.`);
-    expect(exitCode).to.equal(1);
+    expect(exitCode).to.equal(0);
   });
 
 

--- a/src/lib/validateBranch.js
+++ b/src/lib/validateBranch.js
@@ -9,7 +9,7 @@ module.exports = function validateBranch(branch) {
 
   if (branch !== currentBranch) {
     log.error(`You can only release from the ${branch} branch. Use option --branch to specify branch name.`);
-    shell.exit(1);
+    shell.exit(0);
   } else {
     log.info(`>>> Your release branch is: ${branch}`);
   }


### PR DESCRIPTION
BREAKING CHANGE:
Projects that relied on the old when-not-on-master-exit-1 behaviour should use the new
--post-success [cmd] hook to only run subsequent commands when a release occurs.

ISSUES CLOSED: #38