### PR TITLE
feat(app): add flag to commit to signal CI servers to ignore the commit

### DIFF
--- a/spec/system.spec.js
+++ b/spec/system.spec.js
@@ -466,7 +466,7 @@ describe('corp-semantic-release', function() {
   function expectedGitTag(expectedVersion) {
     // check for new commit
     let gitLog = shell.exec('git log | cat').stdout;
-    expect(gitLog).to.include(`chore(release): v${expectedVersion}`);
+    expect(gitLog).to.include(`chore(release): v${expectedVersion} [ci skip]`);
 
     let gitTag = shell.exec('git tag | cat').stdout;
     expect(gitTag).to.include('v' + expectedVersion);

--- a/src/lib/addFilesAndCreateTag.js
+++ b/src/lib/addFilesAndCreateTag.js
@@ -11,7 +11,7 @@ module.exports = function addFilesAndCreateTag(newVersion, mockPush) {
   terminateProcess(code);
 
   // ###### Commit files #####
-  code = shell.exec('git commit -m "chore(release): ' + newVersion + '"').code;
+  code = shell.exec('git commit -m "chore(release): ' + newVersion + ' [ci skip]"').code;
   terminateProcess(code);
 
   // ###### TAG NEW VERSION #####


### PR DESCRIPTION
This avoids CI servers running another build due to changes related to versioning

ISSUES CLOSED: #45