### PR TITLE
chore(build): fix system spec so that the current working directory is reset

### DIFF
--- a/config/testUnit/mocha.opts
+++ b/config/testUnit/mocha.opts
@@ -1,5 +1,5 @@
 spec/**/*.spec.js
---recursive
---reporter list
+--reporter mocha-multi-reporters
+--reporter-options configFile=./config/testUnit/reporters.json
 --no-timeouts
 --ui bdd

--- a/config/testUnit/reporters.json
+++ b/config/testUnit/reporters.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "list, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "reports/junit.xml"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "husky": "0.13.3",
     "mocha": "3.5.3",
     "mocha-junit-reporter": "1.13.0",
+    "mocha-multi-reporters": "1.1.5",
     "npm-run-all": "4.0.2",
     "nyc": "11.1.0",
     "rewire": "2.5.2",

--- a/spec/system.spec.js
+++ b/spec/system.spec.js
@@ -44,6 +44,7 @@ describe('corp-semantic-release', function() {
     shell.cd(__dirname);
     shell.rm('-rf', tempDir);
     tempDir = null;
+    shell.cd('../'); // Navigate back to project root directory. If we don't do this, mocha-multi-reporters complains when it looks for its options file
   });
 
 


### PR DESCRIPTION
Fixes issue with mocha-multi-reporter not being able to find options file - caused by system.spec.js not resetting the current working directory.