### PR TITLE
chore: add node 8 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ notifications:
 node_js:
   - '4'
   - '6'
+  - '8'
   - 'node'
 before_install:
   - npm i -g npm@^3.0.0


### PR DESCRIPTION
Travis CI needs at least one job to run node version 8 in order to kick off the build. 
Related to https://github.com/semantic-release/semantic-release/issues/347 and 
https://github.com/leonardoanalista/corp-semantic-release/issues/54

CLOSES: https://github.com/leonardoanalista/corp-semantic-release/pull/55
